### PR TITLE
Set ADB_INSTALL_TIMEOUT environment variable to 10 minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ android:
     - sys-img-armeabi-v7a-android-22
 
 env:
+  global:
+    - ADB_INSTALL_TIMEOUT=10 # default is 2 minutes
   matrix:
     - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
     - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a


### PR DESCRIPTION
The default being 2 minutes.

Did a 🍒  pick of @cotsog's PR here: 
https://github.com/odra/sync-android-app/pull/1  