### PR TITLE
Downgrade material-dialogs lib version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
-    compile 'com.afollestad.material-dialogs:core:0.9.0.1'
+    compile 'com.afollestad.material-dialogs:core:0.8.6.2'
 }


### PR DESCRIPTION
Android Support library 24.x is a requirement for [https://github.com/afollestad/material-dialogs/releases/tag/0.9.0.0](0.9.x) and for now we don't support 24 yet